### PR TITLE
Update manifest to remove deprecated buildpack attribute

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: dns-lookup
-  buildpack: nodejs_buildpack
+  buildpacks: 
+    - nodejs_buildpack
   memory: 128M
 


### PR DESCRIPTION
Updates manifest to remove this warning. 

Deprecation warning: Use of 'buildpack' attribute in manifest is deprecated in favor of 'buildpacks'. Please see http://docs.cloudfoundry.org/devguide/deplo
y-apps/manifest.html#deprecated for alternatives and other app manifest deprecations. This feature will be removed in the future.

Signed-off-by: Steven Barry <sba30@allstate.com>